### PR TITLE
add loading indicator to slower layer

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1041,7 +1041,7 @@ export default {
           self.nfhlIsDisplayed = "none";
           clearInterval(fadeOut);
         }
-      }, 150);
+      }, 100);
     },
     loadAQdata() {
       this.aqMarkers.clearLayers();
@@ -1418,12 +1418,16 @@ export default {
     currentBounds: function () {
       this.streamgageMarkers.clearLayers();
       this.toggleStreamgage(this.streamgageMarkers, this.currentZoom);
+      this.nfhlLayer.remove();
+      this.getNfhlLayer();
     },
     currentZoom: function () {
       // Update legend on zoom
       if (this.map.hasLayer(this.nfhlLayer) && this.nfhlVisible) {
         let layers = this.nfhlLayer.getLayers();
         this.getNfhlLegend(layers);
+        //this.nfhlLayer.remove();
+        //this.getNfhlLayer();
       }
     },
     "$store.state.streamgageState": function () {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -14,6 +14,20 @@
         ></v-progress-circular>
         <span class="loadingLabel">Loading Layers...</span>
       </div>
+      <div
+        id="nfhlLoadingAlert"
+        class="alert nfhlAlertClass fade"
+        role="alert"
+        :style="{ display: nfhlIsDisplayed, opacity: alertOpacity }"
+        load: 
+      >
+        <v-progress-circular
+          indeterminate
+          :width="3"
+          :size="20"
+        ></v-progress-circular>
+        <span class="loadingLabel">Loading Layer...</span>
+      </div>
 
       <!-- a leaflet map -->
       <div id="map">
@@ -235,6 +249,7 @@ export default {
       alertOpacity: "0.75",
       mvpData: mvpAqData,
       isDisplayed: "none",
+      nfhlIsDisplayed: "none",
       currentZoom: 4,
       currentBounds: {
         _southWest: {
@@ -968,6 +983,21 @@ export default {
         }
       }, 50);
     },
+    nfhlFadeOutAlert() {
+      let opacity = 0.75;
+      let self = this;
+      let fadeOut = setInterval(function () {
+        if (opacity > 0) {
+          opacity -= 0.05;
+          let opacityValue = String(opacity);
+          self.alertOpacity = opacityValue;
+        } else {
+          self.alertOpacity = "0.75";
+          self.nfhlIsDisplayed = "none";
+          clearInterval(fadeOut);
+        }
+      }, 100);
+    },
     loadAQdata() {
       this.aqMarkers.clearLayers();
       let hasMarkers = false;
@@ -1110,6 +1140,7 @@ export default {
       }
     },
     toggleNfhl(nfhlLayer) {
+      
       let container = document.getElementById("nfhlLegend");
       this.nfhlLayer = nfhlLayer;
       if (this.$store.state.nfhlState == true) {
@@ -1124,6 +1155,7 @@ export default {
       }
     },
     getNfhlLayer() {
+      this.nfhlIsDisplayed = "block";
       this.nfhlLayer = esri.dynamicMapLayer({
         url: "https://hazards.fema.gov/gis/nfhl/rest/services/public/NFHL/MapServer",
         // 0: NFHL Availability, 3: FIRM Panels, 14: Cross Sections, 27: Flood Hazard Boundaries, 28: Flood Hazard Zones
@@ -1132,6 +1164,7 @@ export default {
       });
       let layers = this.nfhlLayer.getLayers();
       this.nfhlLayer.addTo(this.map);
+      this.nfhlFadeOutAlert();
       this.getNfhlLegend(layers);
     },
     getNfhlLegend(layers) {
@@ -1382,7 +1415,7 @@ export default {
   padding: 5px;
 }
 
-.nwisAlertClass {
+.nwisAlertClass, .nfhlAlertClass {
   position: absolute;
   top: 10px;
   left: 50px;

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1178,6 +1178,7 @@ export default {
     getNfhlLayer() {
       var self = this;
       self.nfhlIsDisplayed = "block";
+      let zoomlevel = self.currentZoom;
       let nfhlURL = "https://hazards.fema.gov/gis/nfhl/rest/services/public/NFHL/MapServer"
       let extent = this.map.getBounds();
       let bbox =
@@ -1200,15 +1201,20 @@ export default {
         .then(function () {
           // handle success
           console.log("success")
-          self.nfhlFadeOutAlert()
+          self.nfhlFadeOutAlert();
+          if (zoomlevel !== self.currentZoom) {
+              this.fadeOutAlert();
+              return;
+            }
         })
         .catch(function (error) {
           // handle error
           console.log(error);
       })
-
+      
       let layers = this.nfhlLayer.getLayers();
       this.nfhlLayer.addTo(this.map);
+      
       this.getNfhlLegend(layers);
     },
     getNfhlLegend(layers) {

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -12,7 +12,7 @@
           :width="3"
           :size="20"
         ></v-progress-circular>
-        <span class="loadingLabel">Loading Layers...</span>
+        <span class="loadingLabel">Loading Layer...</span>
       </div>
       <div
         id="nfhlLoadingAlert"

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -996,7 +996,7 @@ export default {
           self.nfhlIsDisplayed = "none";
           clearInterval(fadeOut);
         }
-      }, 100);
+      }, 150);
     },
     loadAQdata() {
       this.aqMarkers.clearLayers();

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1424,10 +1424,9 @@ export default {
     currentZoom: function () {
       // Update legend on zoom
       if (this.map.hasLayer(this.nfhlLayer) && this.nfhlVisible) {
+                this.nfhlLegendComponent.remove();
         let layers = this.nfhlLayer.getLayers();
         this.getNfhlLegend(layers);
-        //this.nfhlLayer.remove();
-        //this.getNfhlLayer();
       }
     },
     "$store.state.streamgageState": function () {


### PR DESCRIPTION
let me know what you think. i could see a few issues still such as:
- do we want it to spin again on drag?
- this one doesn't work as nicely as the other because it's a different type of layer. so the timeout is the same rather than based on layer load, which means it's a little slow when zoomed in and a little fast when zoomed out (tho maybe something can happen with the time set based on zoom?)
- it interacts fine with the other one, although the other one says "loading layers" and this one says "loading layer" so they don't overlap 100%. i'm wondering if it's ok to change the other one for the streamgages to "layer" (singular)?