### PR TITLE
132 drawer state default off and slightly slimmer sidebar

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -3,7 +3,7 @@
     v-model="drawerState"
     disable-resize-watcher
     app
-    :width="325"
+    :width="300"
   >
     <div>
       <h2 id="sidebarTitle">Map Filters</h2>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,7 +5,7 @@ Vue.use(Vuex);
 
 export default new Vuex.Store({
   state: {
-    drawerState: true,
+    drawerState: false,
     basemapState: "Topo",
     streamgageState: false,
     radarState: false,


### PR DESCRIPTION
-everything is still centered in sidebar with width 300 instead of 325
-was a simple one word change to have sidebar default off instead of on. this does it for all screensizes not just small. but personally i like that