### PR TITLE
prevent duplication of NFHL

### DIFF
--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1370,7 +1370,7 @@ export default {
       this.streamgageMarkers.clearLayers();
       this.toggleStreamgage(this.streamgageMarkers, this.currentZoom);
       this.nfhlLayer.remove();
-      this.toggleNfhl(this.nfhlLayer, this.currentZoom);
+      this.toggleNfhl(this.nfhlLayer);
     },
     currentZoom: function () {
       // Update legend on zoom

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -1370,7 +1370,7 @@ export default {
       this.streamgageMarkers.clearLayers();
       this.toggleStreamgage(this.streamgageMarkers, this.currentZoom);
       this.nfhlLayer.remove();
-      this.getNfhlLayer();
+      this.toggleNfhl(this.nfhlLayer, this.currentZoom);
     },
     currentZoom: function () {
       // Update legend on zoom


### PR DESCRIPTION
ok last night when i logged off i was able to prevent the duplication of the NFHL LAYER but it would still duplicate sometimes in the LEGEND

testing it this morning, i actually cannot make the legend break!! the name never duplicates in the legend for me (testing in edge, chrome, and firefox)

i am hoping that both of you can spend a few minutes playing around trying to break the legend. try three things:
- toggle the layer on and off quickly
- pan around the map quickly
- zoom quickly

and please let me know how you were able to break it, if you can