### PR TITLE
add tooltips for active flooding layers 184

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--
+- Add tooltips for active flooding
 
 ### Changed
 

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -58,7 +58,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -81,7 +81,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -104,7 +104,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -127,7 +127,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -150,7 +150,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -173,7 +173,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -195,7 +195,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -217,7 +217,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -54,6 +54,20 @@
                     width="25px"
                   />
                   <label>Embankment Flooded</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Flood waters exit the stream/river channel and overflow onto a flat surface</span>
+                  </v-tooltip>
                 </div>
                 <div class="legendIcon" v-if="pathVisible">
                   <img
@@ -63,6 +77,20 @@
                     width="25px"
                   />
                   <label>Path Flooded</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Flood waters are flooding a pedestrian greenway/trail/path</span>
+                  </v-tooltip>
                 </div>
                 <div class="legendIcon" v-if="roadVisible">
                   <img
@@ -72,6 +100,20 @@
                     width="25px"
                   />
                   <label>Road Flooded</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Low lying areas along roads are flooding</span>
+                  </v-tooltip>
                 </div>
                 <div class="legendIcon" v-if="bridgeRiskVisible">
                   <img
@@ -81,6 +123,20 @@
                     width="25px"
                   />
                   <label>Bridge Flood at Risk</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Water from a river or stream is under the lowest section of a bridge</span>
+                  </v-tooltip>
                 </div>
                 <div class="legendIcon" v-if="bridgeFloodedVisible">
                   <img
@@ -90,6 +146,20 @@
                     width="25px"
                   />
                   <label>Bridge Flooded</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>A bridge is flooding</span>
+                  </v-tooltip>
                 </div>
                 <div class="legendIcon" v-if="facilityVisible">
                   <img
@@ -99,6 +169,20 @@
                     width="25px"
                   />
                   <label>Facility Flooded</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Structures/facilities are flooding</span>
+                  </v-tooltip>
                 </div>
                 <div class="legendIcon" v-if="bfeVisible">
                   <img
@@ -107,6 +191,20 @@
                     width="25px"
                   />
                   <label>Base Flood Elevation</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>The FEMA 100-year BFE has been reached</span>
+                  </v-tooltip>
                 </div>
                 <div class="legendIcon" v-if="otherVisible">
                   <img
@@ -115,6 +213,20 @@
                     width="25px"
                   />
                   <label>Uncategorized</label>
+                    <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Other Reference Points are experiencing flooding (parking lot, campground, railroad, etc).</span>
+                  </v-tooltip>
                 </div>
               </div>
               <!-- Toggleable layers -->
@@ -1748,7 +1860,7 @@ export default {
   right: 10px;
   top: 45px;
   height: auto;
-  width: 225px;
+  width: 230px;
   position: absolute;
   z-index: 999;
   font-size: 14px;
@@ -1810,7 +1922,8 @@ export default {
   display: inline-block;
   -webkit-justify-content: center;
   justify-content: center;
-  padding-left: 10px;
+  padding-left: 4px;
+  padding-right: 2px;
 }
 
 .legendIconToggle {

--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -111,6 +111,20 @@
                 <label for="bank" class="legend-label"
                   >Embankment Flooded</label
                 >
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Flood waters exit the stream/river channel and overflow onto a flat surface</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -128,6 +142,20 @@
                   src="../assets/aq-icons/path_flooded_circle.png"
                 />
                 <label for="path" class="legend-label">Path Flooded</label>
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Flood waters are flooding a pedestrian greenway/trail/path</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -145,6 +173,20 @@
                   src="../assets/aq-icons/car_flooded_circle.png"
                 />
                 <label for="road" class="legend-label">Road Flooded</label>
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Low lying areas along roads are flooding</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -164,6 +206,20 @@
                 <label for="bridgeRisk" class="legend-label"
                   >Bridge Flood at Risk</label
                 >
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Water from a river or stream is under the lowest section of a bridge</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -181,6 +237,20 @@
                   src="../assets/aq-icons/bridge_flooded_circle.png"
                 />
                 <label for="bridge" class="legend-label">Bridge Flooded</label>
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>A bridge is flooding</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -200,6 +270,20 @@
                 <label for="facility" class="legend-label"
                   >Facility Flooded</label
                 >
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Structures/facilities are flooding</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -216,6 +300,20 @@
                 <label for="bfe" class="legend-label"
                   >Base Flood Elevation</label
                 >
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>The FEMA 100-year BFE has been reached</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -230,6 +328,20 @@
               <div class="sublayer-icon">
                 <img class="activeIcons" src="../assets/aq-icons/other.png" />
                 <label for="other" class="legend-label">Uncategorized</label>
+                  <v-tooltip right>
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-icon
+                        small
+                        color="primary"
+                        dark
+                        v-bind="attrs"
+                        v-on="on"
+                      >
+                        mdi-information
+                      </v-icon>
+                    </template>
+                    <span>Other Reference Points are experiencing flooding (parking lot, campground, railroad, etc).</span>
+                  </v-tooltip>
               </div>
               <br />
             </div>
@@ -604,10 +716,11 @@ export default {
 
 .legend-label {
   margin-left: -2px;
+  padding-right: 2px;
 }
 
 #activeSublayers {
-  padding-left: 20px;
+  padding-left: 8px;
 }
 
 .activeIcons {

--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -115,7 +115,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -146,7 +146,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -177,7 +177,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -210,7 +210,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -241,7 +241,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -274,7 +274,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -304,7 +304,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -332,7 +332,7 @@
                     <template v-slot:activator="{ on, attrs }">
                       <v-icon
                         small
-                        color="primary"
+                        color="blue lighten-1"
                         dark
                         v-bind="attrs"
                         v-on="on"
@@ -351,7 +351,7 @@
               id="showAll"
               small
               outlined
-              color="primary"
+              color="blue lighten-1"
               @click="callShowAll"
               >Show all active flooding</v-btn
             >


### PR DESCRIPTION
lauren/abby tell me how u think this looks (we can ask daniel too?)
lauren had said to include tooltips in the sidebar and legend. which when only one of them is open i think makes sense, but when they're both open i'm afraid it's overwhelming? what do u think
it could also maybe be less overwhelming if not a bright blue? i like the bright blue when it's just one of the two, i think it matches the theme and stands out (in fact, it makes me want to reconsider the grey tooltips in wqp to something brighter)
but perhaps if it were duller then having two would work?