### PR TITLE
246 - display all threshold icons in sidebar and legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
 ## [Unreleased](https://github.com/USGS-WiM/Thresholds/tree/dev)
 
 ### Added
 
-- 
+-
 
 ### Changed
 
 - Update about text
+- Added all threshold icons to sidebar and legend. Icons without active flooding are disabled in sidebar.
 
 ### Fixed
 
-- 
-
+-
 
 ## [v0.7.0](https://github.com/USGS-WiM/Thresholds/releases/tag/v0.7.0) - 9/29/2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
--
+- Added alert to sidebar for "No Flooded Features"
+- Added tooltip to "No Active Layers" text 
 
 ### Changed
 

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -56,7 +56,7 @@
             <!-- Threshold icons -->
               <div id="thresholdLayers">
                 <div id="thresholdLayersTitle" v-if="activeLayerTitleVisible">Active Flooding</div>
-                <div class="legendIcon" v-if="bankVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/embankment_flooded_circle.png"
                     height="25px"
@@ -78,7 +78,7 @@
                     <span>Flood waters exit the stream/river channel and overflow onto a flat surface</span>
                   </v-tooltip>
                 </div>
-                <div class="legendIcon" v-if="pathVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/path_flooded_circle.png"
                     alt=""
@@ -101,7 +101,7 @@
                     <span>Flood waters are flooding a pedestrian greenway/trail/path</span>
                   </v-tooltip>
                 </div>
-                <div class="legendIcon" v-if="roadVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/car_flooded_circle.png"
                     alt=""
@@ -124,7 +124,7 @@
                     <span>Low lying areas along roads are flooding</span>
                   </v-tooltip>
                 </div>
-                <div class="legendIcon" v-if="bridgeRiskVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/bridge_risk_circle.png"
                     alt=""
@@ -147,7 +147,7 @@
                     <span>Water from a river or stream is under the lowest section of a bridge</span>
                   </v-tooltip>
                 </div>
-                <div class="legendIcon" v-if="bridgeFloodedVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/bridge_flooded_circle.png"
                     alt=""
@@ -170,7 +170,7 @@
                     <span>A bridge is flooding</span>
                   </v-tooltip>
                 </div>
-                <div class="legendIcon" v-if="facilityVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/building_flooded_circle.png"
                     alt=""
@@ -193,7 +193,7 @@
                     <span>Structures/facilities are flooding</span>
                   </v-tooltip>
                 </div>
-                <div class="legendIcon" v-if="bfeVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/BFE.png"
                     height="25px"
@@ -215,7 +215,7 @@
                     <span>The FEMA 100-year BFE has been reached</span>
                   </v-tooltip>
                 </div>
-                <div class="legendIcon" v-if="otherVisible">
+                <div class="legendIcon">
                   <img
                     src="../assets/aq-icons/other.png"
                     height="25px"
@@ -1245,17 +1245,37 @@ export default {
       this.facilityLayer.clearLayers();
       this.otherLayer.clearLayers();
       this.bfeLayer.clearLayers();
-      document.getElementById("bankDiv").style.display = "none";
-      document.getElementById("pathDiv").style.display = "none";
-      document.getElementById("roadDiv").style.display = "none";
-      document.getElementById("bridgeRiskDiv").style.display = "none";
-      document.getElementById("bridgeDiv").style.display = "none";
-      document.getElementById("facilityDiv").style.display = "none";
-      document.getElementById("bfeDiv").style.display = "none";
-      document.getElementById("otherDiv").style.display = "none";
+      this.bankVisible = false,
+      this.pathVisible = false,
+      this.roadVisible = false,
+      this.bridgeRiskVisible = false,
+      this.bridgeFloodedVisible = false,
+      this.facilityVisible = false,
+      this.otherVisible = false,
+      this.bfeVisible = false,
+      this.$store.state.bankState = false;
+      this.$store.state.pathState = false;
+      this.$store.state.roadState = false;
+      this.$store.state.bridgeRiskState = false;
+      this.$store.state.bridgeState = false;
+      this.$store.state.facilityState = false;
+      this.$store.state.otherState = false;
+      this.$store.state.bfeState = false;
+      document.getElementById("bankDiv").style.opacity = 0.6;
+      document.getElementById("pathDiv").style.opacity = 0.6;
+      document.getElementById("roadDiv").style.opacity = 0.6;
+      document.getElementById("bridgeRiskDiv").style.opacity = 0.6;
+      document.getElementById("bridgeDiv").style.opacity = 0.6;
+      document.getElementById("facilityDiv").style.opacity = 0.6;
+      document.getElementById("bfeDiv").style.opacity = 0.6;
+      document.getElementById("otherDiv").style.opacity = 0.6;
       let hasMarkers = false;
       let entryCount = 0;
       this.thresholdsExceeded = 0;
+      this.activeLayerTitleVisible = false;
+      document.getElementById("activeLayerTitle").style.display = "none";
+      document.getElementById("noActiveFlooding").style.display = "none";
+      document.getElementById("showAllBtn").style.display = "none";
 
       // adding rp/threshold data from Aquarius
       for (let entry in this.mvpData) {
@@ -1339,7 +1359,8 @@ export default {
               if (Name === "PATH") {
                 this.pathVisible = true;
                 this.$store.state.pathState = true;
-                document.getElementById("pathDiv").style.display = "block";
+                document.getElementById("pathDiv").style.opacity = 1;
+                this.$store.commit("getPathDisabledState", false);
                 if(this.activeSubtypes.includes("path") === false){
                   this.activeSubtypes.push("path");
                 }
@@ -1351,8 +1372,9 @@ export default {
                 this.thresholdsExceeded ++;
               } else if (Name === "BANK") {
                 this.bankVisible = true;
-                document.getElementById("bankDiv").style.display = "block";
                 this.$store.state.bankState = true;
+                document.getElementById("bankDiv").style.opacity = 1;
+                this.$store.commit("getBankDisabledState", false);
                 if(this.activeSubtypes.includes("bank") === false){
                   this.activeSubtypes.push("bank");
                 }
@@ -1364,8 +1386,9 @@ export default {
                 this.thresholdsExceeded ++;
               } else if (Name === "ROAD") {
                 this.roadVisible = true;
-                document.getElementById("roadDiv").style.display = "block";
                 this.$store.state.roadState = true;
+                document.getElementById("roadDiv").style.opacity = 1;
+                this.$store.commit("getRoadDisabledState", false);
                 if(this.activeSubtypes.includes("road") === false){
                   this.activeSubtypes.push("road");
                 }
@@ -1377,10 +1400,11 @@ export default {
                 this.thresholdsExceeded ++;
               } else if (Name === "CHORD") {
                 this.bridgeRiskVisible = true;
-                document.getElementById("bridgeRiskDiv").style.display = "block";
                 this.$store.state.bridgeRiskState = true;
-                if(this.activeSubtypes.includes("bridgeRiskDiv") === false){
-                  this.activeSubtypes.push("bridgeRiskDiv");
+                document.getElementById("bridgeRiskDiv").style.opacity = 1;
+                this.$store.commit("getBridgeRiskDisabledState", false);
+                if(this.activeSubtypes.includes("bridgeRisk") === false){
+                  this.activeSubtypes.push("bridgeRisk");
                 }
                 marker = L.marker([lat, lng], {
                   icon: aqIcon,
@@ -1390,8 +1414,9 @@ export default {
                 this.thresholdsExceeded ++;
               } else if (Name === "FACILITY") {
                 this.facilityVisible = true;
-                document.getElementById("facilityDiv").style.display = "block";
                 this.$store.state.facilityState = true;
+                document.getElementById("facilityDiv").style.opacity = 1
+                this.$store.commit("getFacilityDisabledState", false);
                 if(this.activeSubtypes.includes("facility") === false){
                   this.activeSubtypes.push("facility");
                 }
@@ -1403,8 +1428,9 @@ export default {
                 this.thresholdsExceeded ++;
               } else if (Name === "DECK") {
                 this.bridgeFloodedVisible = true;
-                document.getElementById("bridgeDiv").style.display = "block";
                 this.$store.state.bridgeState = true;
+                document.getElementById("bridgeDiv").style.opacity = 1;
+                this.$store.commit("getBridgeDisabledState", false);
                 if(this.activeSubtypes.includes("bridgeFlooded") === false){
                   this.activeSubtypes.push("bridgeFlooded");
                 }
@@ -1416,8 +1442,9 @@ export default {
                 this.thresholdsExceeded ++;
               } else if (Name === "BFE") {
                 this.bfeVisible = true;
-                document.getElementById("bfeDiv").style.display = "block";
                 this.$store.state.bfeState = true;
+                document.getElementById("bfeDiv").style.opacity = 1;
+                this.$store.commit("getBfeDisabledState", false);
                 if(this.activeSubtypes.includes("bfe") === false){
                   this.activeSubtypes.push("bfe");
                 }
@@ -1429,8 +1456,9 @@ export default {
                 this.thresholdsExceeded ++;
               } else {
                 this.otherVisible = true;
-                document.getElementById("otherDiv").style.display = "block";
                 this.$store.state.otherState = true;
+                document.getElementById("otherDiv").style.opacity = 1
+                this.$store.commit("getOtherDisabledState", false);
                 if(this.activeSubtypes.includes("other") === false){
                   this.activeSubtypes.push("other");
                 }
@@ -1489,6 +1517,7 @@ export default {
                 this.activeLayerTitleVisible = false;
                 document.getElementById("noActiveFlooding").style.display = "block";
                 this.$store.commit("getThresholdsExceededCount", this.thresholdsExceeded);
+                this.map.setView(this.center, 4) 
               }
             }
           }else{

--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -137,8 +137,9 @@
                   </v-icon>
                 </template>
                 <span
-                  >The Layers below are disabled because no locations are
-                  currently flooding.</span
+                  >The layers below are disabled because no locations are
+                  currently flooding. Change the date above to view possible
+                  flooding on past dates.</span
                 >
               </v-tooltip>
             </div>

--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -109,13 +109,17 @@
             </div>
             <div id="timePeriod"><DatePicker></DatePicker></div>
             <div id="activeLayerTitle">Active Flooding Layers</div>
+            <div style="display: none" id="noActiveFlooding">
+              No Active Flooding
+            </div>
             <div id="activeSublayers">
-              <div id="bankDiv" style="display: none">
+              <div id="bankDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="bank"
                   id="bank"
                   value="true"
+                  :disabled="bankDisabled"
                   v-model="bankPicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -146,12 +150,13 @@
                 </div>
                 <br />
               </div>
-              <div id="pathDiv" style="display: none">
+              <div id="pathDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="path"
                   id="path"
                   value="true"
+                  :disabled="pathDisabled"
                   v-model="pathPicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -180,12 +185,13 @@
                 </div>
                 <br />
               </div>
-              <div id="roadDiv" style="display: none">
+              <div id="roadDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="road"
                   id="road"
                   value="true"
+                  :disabled="roadDisabled"
                   v-model="roadPicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -211,12 +217,13 @@
                 </div>
                 <br />
               </div>
-              <div id="bridgeRiskDiv" style="display: none">
+              <div id="bridgeRiskDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="bridgeRisk"
                   id="bridgeRisk"
                   value="true"
+                  :disabled="bridgeRiskDisabled"
                   v-model="bridgeRiskPicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -247,12 +254,13 @@
                 </div>
                 <br />
               </div>
-              <div id="bridgeDiv" style="display: none">
+              <div id="bridgeDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="bridge"
                   id="bridge"
                   value="true"
+                  :disabled="bridgeDisabled"
                   v-model="bridgePicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -280,12 +288,13 @@
                 </div>
                 <br />
               </div>
-              <div id="facilityDiv" style="display: none">
+              <div id="facilityDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="facility"
                   id="facility"
                   value="true"
+                  :disabled="facilityDisabled"
                   v-model="facilityPicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -313,12 +322,13 @@
                 </div>
                 <br />
               </div>
-              <div id="bfeDiv" style="display: none">
+              <div id="bfeDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="bfe"
                   id="bfe"
                   value="true"
+                  :disabled="bfeDisabled"
                   v-model="bfePicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -343,12 +353,13 @@
                 </div>
                 <br />
               </div>
-              <div id="otherDiv" style="display: none">
+              <div id="otherDiv">
                 <v-simple-checkbox
                   type="checkbox"
                   ref="other"
                   id="other"
                   value="true"
+                  :disabled="otherDisabled"
                   v-model="otherPicked"
                 ></v-simple-checkbox>
                 <div class="sublayer-icon">
@@ -386,9 +397,6 @@
                 >Show all active flooding layers</v-btn
               >
             </div>
-            <div style="display: none" id="noActiveFlooding">
-              No Active Flooding
-            </div>
             <v-simple-checkbox
               type="checkbox"
               ref="allRP"
@@ -400,9 +408,7 @@
               <div
                 class="wmm-circle wmm-white wmm-icon-noicon wmm-size-20"
               ></div>
-              <label for="allRP" class="legend-label"
-                >All Features</label
-              >
+              <label for="allRP" class="legend-label">All Features</label>
             </div>
             <br />
             <div class="zoom-alert" :style="{ display: isDisplayed }">
@@ -601,12 +607,28 @@ export default {
         return this.$store.commit("getBankState", value);
       },
     },
+    bankDisabled: {
+      get() {
+        return this.$store.state.bankDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getBankDisabledState", value);
+      },
+    },
     pathPicked: {
       get() {
         return this.$store.state.pathState;
       },
       set(value) {
         return this.$store.commit("getPathState", value);
+      },
+    },
+    pathDisabled: {
+      get() {
+        return this.$store.state.pathDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getPathDisabledState", value);
       },
     },
     roadPicked: {
@@ -617,12 +639,28 @@ export default {
         return this.$store.commit("getRoadState", value);
       },
     },
+    roadDisabled: {
+      get() {
+        return this.$store.state.roadDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getRoadDisabledState", value);
+      },
+    },
     bridgeRiskPicked: {
       get() {
         return this.$store.state.bridgeRiskState;
       },
       set(value) {
         return this.$store.commit("getBridgeRiskState", value);
+      },
+    },
+    bridgeRiskDisabled: {
+      get() {
+        return this.$store.state.bridgeRiskDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getBridgeRiskDisabledState", value);
       },
     },
     bridgePicked: {
@@ -633,12 +671,28 @@ export default {
         return this.$store.commit("getBridgeState", value);
       },
     },
+    bridgeDisabled: {
+      get() {
+        return this.$store.state.bridgeDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getBridgeDisabledState", value);
+      },
+    },
     facilityPicked: {
       get() {
         return this.$store.state.facilityState;
       },
       set(value) {
         return this.$store.commit("getFacilityState", value);
+      },
+    },
+    facilityDisabled: {
+      get() {
+        return this.$store.state.facilityDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getFacilityDisabledState", value);
       },
     },
     bfePicked: {
@@ -649,12 +703,28 @@ export default {
         return this.$store.commit("getBfeState", value);
       },
     },
+    bfeDisabled: {
+      get() {
+        return this.$store.state.bfeDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getBfeDisabledState", value);
+      },
+    },
     otherPicked: {
       get() {
         return this.$store.state.otherState;
       },
       set(value) {
         return this.$store.commit("getOtherState", value);
+      },
+    },
+    otherDisabled: {
+      get() {
+        return this.$store.state.otherDisabled;
+      },
+      set(value) {
+        return this.$store.commit("getOtherDisabledState", value);
       },
     },
     showAllDisabled: {

--- a/src/components/MapFilters.vue
+++ b/src/components/MapFilters.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <v-alert
+      v-if="isFlooding"
       class="threshold-alert"
       border="left"
       dense
@@ -10,6 +11,18 @@
       icon="mdi-alert"
     >
       {{ thresholdsExceededMessage }} Flooded Features
+    </v-alert>
+    <v-alert
+      v-if="!isFlooding"
+      class="noflooding-alert"
+      border="left"
+      dense
+      colored-border
+      type="success"
+      elevation="2"
+      icon="mdi-checkbox-marked-circle"
+    >
+      No Flooded Features
     </v-alert>
     <v-expansion-panels :value="1">
       <!-- Filters Section -->
@@ -111,6 +124,23 @@
             <div id="activeLayerTitle">Active Flooding Layers</div>
             <div style="display: none" id="noActiveFlooding">
               No Active Flooding
+              <v-tooltip right>
+                <template v-slot:activator="{ on, attrs }">
+                  <v-icon
+                    small
+                    color="blue lighten-1"
+                    dark
+                    v-bind="attrs"
+                    v-on="on"
+                  >
+                    mdi-information
+                  </v-icon>
+                </template>
+                <span
+                  >The Layers below are disabled because no locations are
+                  currently flooding.</span
+                >
+              </v-tooltip>
             </div>
             <div id="activeSublayers">
               <div id="bankDiv">
@@ -527,6 +557,7 @@ export default {
       streamCheckDisabled: true,
       isDisplayed: "block",
       thresholdsExceededMessage: "0",
+      isFlooding: false,
     };
   },
   props: ["currentZoom"],
@@ -751,9 +782,9 @@ export default {
       this.thresholdsExceededMessage =
         this.$store.state.thresholdsExceededCount.toString();
       if (this.thresholdsExceededMessage !== "0") {
-        document
-          .querySelector(".threshold-alert")
-          .style.setProperty("display", "block", "important");
+        this.isFlooding = true;
+      } else {
+        this.isFlooding = false;
       }
     },
   },
@@ -931,6 +962,11 @@ export default {
 .threshold-alert {
   font-weight: bold;
   color: #fb8c00 !important;
-  display: none !important;
+  display: block !important;
+}
+.noflooding-alert {
+  font-weight: bold;
+  color: #00ab2e !important;
+  display: block !important;
 }
 </style>

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -14,13 +14,21 @@ export default new Vuex.Store({
     nfhlState: false,
     allRPState: true,
     bankState: false,
+    bankDisabled: true,
     pathState: false,
+    pathDisabled: true,
     roadState: false,
+    roadDisabled: true,
     bridgeRiskState: false,
+    bridgeRiskDisabled: true,
     bridgeState: false,
+    bridgeDisabled: true,
     facilityState: false,
+    facilityDisabled: true,
     bfeState: false,
+    bfeDisabled: true,
     otherState: false,
+    otherDisabled: true,
     fwwState: false,
     noaaState: false,
     currentZoomState: 4,
@@ -56,26 +64,50 @@ export default new Vuex.Store({
     getBankState(state, bankPicked) {
       state.bankState = bankPicked;
     },
+    getBankDisabledState(state, bankDisabled) {
+      state.bankDisabled = bankDisabled;
+    },
     getPathState(state, pathPicked) {
       state.pathState = pathPicked;
+    },
+    getPathDisabledState(state, pathDisabled) {
+      state.pathDisabled = pathDisabled;
     },
     getRoadState(state, roadPicked) {
       state.roadState = roadPicked;
     },
+    getRoadDisabledState(state, roadDisabled) {
+      state.roadDisabled = roadDisabled;
+    },
     getBridgeRiskState(state, bridgeRiskPicked) {
       state.bridgeRiskState = bridgeRiskPicked;
+    },
+    getBridgeRiskDisabledState(state, bridgeRiskDisabled) {
+      state.bridgeRiskDisabled = bridgeRiskDisabled;
     },
     getBridgeState(state, bridgePicked) {
       state.bridgeState = bridgePicked;
     },
+    getBridgeDisabledState(state, bridgeDisabled) {
+      state.bridgeDisabled = bridgeDisabled;
+    },
     getFacilityState(state, facilityPicked) {
       state.facilityState = facilityPicked;
+    },
+    getFacilityDisabledState(state, facilityDisabled) {
+      state.facilityDisabled = facilityDisabled;
     },
     getBfeState(state, bfePicked) {
       state.bfeState = bfePicked;
     },
+    getBfeDisabledState(state, bfeDisabled) {
+      state.bfeDisabled = bfeDisabled;
+    },
     getOtherState(state, otherPicked) {
       state.otherState = otherPicked;
+    },
+    getOtherDisabledState(state, otherDisabled) {
+      state.otherDisabled = otherDisabled;
     },
     getCurrentZoomState(state, currentZoom) {
       state.currentZoomState = currentZoom;


### PR DESCRIPTION
Let me know if this doesn't line up with what was discussed in the meeting.

I left in the "No active flooding" label in the sidebar when all icons are disabled, but I'm wondering if we should just keep the "Active Flooding Layers" title there now that any icons in the list without active flooding will be disabled:
![image](https://user-images.githubusercontent.com/54085652/135918115-e7206e77-73e5-45a5-a69f-93401fbfd9cf.png)
![activeflooding](https://user-images.githubusercontent.com/54085652/135918209-e4ffba1a-7a56-402b-9c2e-205b96513231.PNG)

