### PR TITLE
#251 - add last transmitted date and gage height to graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added alert to sidebar for "No Flooded Features"
 - Added tooltip to "No Active Layers" text
+- Added last updated date and gage height to AQ popup headers
 
 ### Changed
 

--- a/src/components/Map.vue
+++ b/src/components/Map.vue
@@ -935,6 +935,10 @@ export default {
         document.getElementById("noDataMessageAQ").remove();
       }
 
+      if (document.getElementById("aqGraphHeader") != null) {
+        document.getElementById("aqGraphHeader").remove();
+      }
+
       // storing layer data and setting site id
       let layerData = e.layer.data;
       let siteID = e.layer.data.LocationIdentifier;
@@ -1050,6 +1054,17 @@ export default {
           let values = [];
           let plotlyAnnotations = [];
 
+          let ampm = "AM";
+          let mostRecentDate = new Date(data.data.data[0].time_series_data[data.data.data[0].time_series_data.length - 1][0]);
+          let hour = mostRecentDate.getHours();
+          if(hour > 12){
+            hour = hour - 12;
+            hour = hour.toString().padStart(2, '0');
+            ampm = "PM";
+          }
+          mostRecentDate = (mostRecentDate.getMonth() + 1) + '/' + mostRecentDate.getDate().toString().padStart(2, '0')  + "/" + mostRecentDate.getFullYear() + " " + hour + ":" + mostRecentDate.getMinutes().toString().padStart(2, '0');
+          let mostRecentHeight = data.data.data[0].time_series_data[data.data.data[0].time_series_data.length - 1][1];
+          document.getElementById("aqGraphHeader").innerHTML += `<b>Last Updated: </b>${mostRecentDate} ${ampm}<br><b>Last Updated Gage Height: </b>${mostRecentHeight} feet`;
           // Create x and y arrays for NWIS trace
           data.data.data[0].time_series_data.forEach(function (time) {
             dates.push(new Date(time[0]));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/54085652/136252412-b07aada2-710a-4d3a-8443-7cfd257e1a3d.png)

I couldn't remember the exact wording that was decided on.  I think it was decided that "last transmitted" or "instantaneous value" were too technical.  I used "last updated" - let me know if I should change the wording to something else though.